### PR TITLE
Add @Throws annotations to navigation wrapper entry points

### DIFF
--- a/surveyengine/src/commonMain/kotlin/com/qlarr/surveyengine/usecase/NavigationUseCaseWrapper.kt
+++ b/surveyengine/src/commonMain/kotlin/com/qlarr/surveyengine/usecase/NavigationUseCaseWrapper.kt
@@ -11,11 +11,13 @@ import kotlin.js.JsExport
 @JsExport
 interface NavigationUseCaseWrapper {
     // Serialized NavigationJsonOutput
+    @Throws(Throwable::class)
     fun navigate(scriptEngine: ScriptEngineNavigate): String
     fun getNavigationScript(): String
     fun processNavigationResult(scriptResult: String): String
 
     companion object {
+        @Throws(Throwable::class)
         fun init(
             values: String = "{}",
             processedSurvey: String,


### PR DESCRIPTION
## Summary

Adds `@Throws(Throwable::class)` to the two fallible public entry points of `NavigationUseCaseWrapper`:

- `navigate(scriptEngine: ScriptEngineNavigate)` — runs the script engine and produces navigation output, which can fail at runtime.
- `init(...)` (companion factory) — parses caller-supplied JSON via `jsonMapper.parseToJsonElement(values).jsonObject`, which can throw on malformed input.

## Why

This is a KMP module that is `@JsExport`ed and consumed from native (Swift/Objective-C) via Kotlin/Native interop. Without `@Throws`, a Kotlin exception crossing the interop boundary causes a hard crash instead of a catchable error. Declaring `@Throws(Throwable::class)` generates a `throws` signature so native callers can `try`/`catch` these failures rather than crashing.

The remaining interface methods (`getNavigationScript`, `processNavigationResult`) are left unannotated as they are not expected to throw.